### PR TITLE
makefile: Automate version bump via make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,54 @@
+# ===== Artifact Variables =====
 # Get the current date in YYYYMMDD format
 DATE := $(shell date +%Y%m%d)
-
-# Prefix to use for cleaning / creating
 ZIP_NAME_PREFIX := flatcar-deployment-package
+ZIP_NAME := $(ZIP_NAME_PREFIX)-$(DATE).zip
 
-# Name of the output zip file
-ZIP_NAME := "${ZIP_NAME_PREFIX}-${DATE}.zip"
+define fetch_flatcar_version
+$(shell sh -c 'curl -fsSL https://$1.release.flatcar-linux.net/amd64-usr/current/version.txt \
+  | sed -n "s/^FLATCAR_VERSION=//p"')
+endef
 
-# Default target to create the zip
+STABLE_VERSION = $(call fetch_flatcar_version,stable)
+BETA_VERSION   = $(call fetch_flatcar_version,beta)
+ALPHA_VERSION  = $(call fetch_flatcar_version,alpha)
+
+# ===== Convert the version number to dashed =====
+dot_to_dash = $(subst .,-,$(1))
+export STABLE_VERSION_DASHED := $(call dot_to_dash,$(STABLE_VERSION))
+export BETA_VERSION_DASHED   := $(call dot_to_dash,$(BETA_VERSION))
+export ALPHA_VERSION_DASHED  := $(call dot_to_dash,$(ALPHA_VERSION))
+
+# ===== Paths =====
+OUTPUTS := metadata.display.yaml metadata.yaml main.tf variables.tf
+
+# ===== Default =====
 all: package
 
-# Rule to create the zip file
-package: clean
-	zip -r $(ZIP_NAME) *.tf *.yaml LICENSE README.md
+# check if version have been fetched properly.
+# FIXME: handle multiple channel failures
+check-versions:
+	@test -n "$(STABLE_VERSION)" || (echo "Error: STABLE_VERSION is empty (fetch failed?). Pass STABLE_VERSION explicitly"; exit 1)
+	@test -n "$(BETA_VERSION)"   || (echo "Error: BETA_VERSION is empty (fetch failed?). Pass BETA_VERSION explicitly"; exit 1)
+	@test -n "$(ALPHA_VERSION)"  || (echo "Error: ALPHA_VERSION is empty (fetch failed?). Pass ALPHA_VERSION explicitly"; exit 1)
+
+$(OUTPUTS): %: %.in | check-versions
+	envsubst '$$STABLE_VERSION_DASHED $$BETA_VERSION_DASHED $$ALPHA_VERSION_DASHED' < $< > $@
+
+# create the zip to upload to GCP
+package: $(ZIP_NAME)
+$(ZIP_NAME): $(OUTPUTS) LICENSE README.md
+	rm -f -- $@
+	zip -r $@ $^ >/dev/null 2>&1 || true
+	@echo "Created: $@"
 
 # Clean target to remove the zip file
 clean:
-	rm -f $(ZIP_NAME_PREFIX)-*.zip
+	rm -rf $(ZIP_NAME_PREFIX)-*.zip
+
+show:
+	@echo "Stable: $(STABLE_VERSION) -> $(STABLE_VERSION_DASHED)"
+	@echo "Beta:   $(BETA_VERSION)   -> $(BETA_VERSION_DASHED)"
+	@echo "Alpha:  $(ALPHA_VERSION)  -> $(ALPHA_VERSION_DASHED)"
+
+.PHONY: all package clean show check-versions

--- a/main.tf.in
+++ b/main.tf.in
@@ -1,0 +1,65 @@
+provider "google" {
+  project = var.project_id
+  # If needed, also specify region or credentials here.
+}
+
+locals {
+  image_map = {
+    "stable" = "flatcar-stable-${STABLE_VERSION_DASHED}"
+    "beta"   = "flatcar-beta-${BETA_VERSION_DASHED}"
+    "alpha"  = "flatcar-alpha-${ALPHA_VERSION_DASHED}"
+  }
+
+  flatcar_image = var.flatcar_image == "" ?
+    "projects/kinvolk-public/global/images/${lookup(local.image_map, var.channel, "flatcar-stable-${STABLE_VERSION_DASHED}")}" :
+    var.flatcar_image
+
+  external_ip = length(var.external_ip) > 0 ? var.external_ip[0] : null
+
+  has_external_ip = (
+    local.external_ip != null &&
+    local.external_ip != "NONE"
+  )
+
+  can_ip_forward = (lower(var.ip_forward) == "on") ? true : false
+}
+
+resource "google_compute_instance" "flatcar_vm" {
+  name         = "${var.goog_cm_deployment_name}-vm"
+  zone         = var.zone
+  machine_type = var.machine_type
+  can_ip_forward = local.can_ip_forward
+
+  boot_disk {
+    initialize_params {
+      size  = var.boot_disk_size_gb
+      type  = var.boot_disk_type
+      image = local.flatcar_image
+    }
+  }
+
+  network_interface {
+    network    = length(var.network) > 0 ? var.network[0] : "default"
+    subnetwork = length(var.subnetwork) > 0 ? var.subnetwork[0] : null
+
+    access_config {
+      nat_ip = local.has_external_ip && local.external_ip != "EPHEMERAL" ? local.external_ip : null
+    }
+  }
+
+  service_account {
+    email  = "default"
+    scopes = [
+      "https://www.googleapis.com/auth/cloud.useraccounts.readonly",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring.write",
+    ]
+  }
+
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
+  tags = [ "${var.deployment_name}-deployment" ]
+}

--- a/metadata.display.yaml.in
+++ b/metadata.display.yaml.in
@@ -1,0 +1,105 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: flatcar-gcp-marketplace
+  annotations:
+    autogenSpecType: SINGLE_VM
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Flatcar Container Linux on Google Cloud Platform (GCP)
+    source:
+      repo: https://github.com/flatcar/terraform-gcp-flatcar.git
+      sourceType: git
+      dir: /
+  ui:
+    input:
+      variables:
+        boot_disk_size:
+          name: disk_size
+          title: Disk Size
+          section: boot_disk
+          xGoogleProperty:
+            type: ET_GCE_DISK_SIZE
+            gceDiskSize:
+              diskTypeVariable: boot_disk_type
+        boot_disk_type:
+          name: boot_disk_type
+          title: Boot Disk Type
+          section: boot_disk
+          xGoogleProperty:
+            type: ET_GCE_DISK_TYPE
+            zoneProperty: zone
+        goog_cm_deployment_name:
+          name: goog_cm_deployment_name
+          title: Goog Cm Deployment Name
+        machine_type:
+          name: machine_type
+          title: Machine Type
+          xGoogleProperty:
+            type: ET_GCE_MACHINE_TYPE
+            zoneProperty: zone
+        name:
+          name: name
+          title: Name
+        network_interface:
+          name: network_interface
+          title: Network Interface
+          minItems: 1
+          maxItems: 8
+          section: networking
+          xGoogleProperty:
+            type: ET_GCE_NETWORK
+            gceNetwork:
+              allowSharedVpcs: true
+              machineTypeVariable: machine_type
+        sub_networks:
+          name: sub_networks
+          title: Subnetwork name
+          minItems: 1
+          maxItems: 8
+          section: networking
+          xGoogleProperty:
+            type: ET_GCE_SUBNETWORK
+            zoneProperty: zone
+            gceSubnetwork:
+              networkVariable: networks
+        external_ips:
+          name: external_ips
+          title: External IP
+          tooltip: An external IP address associated with this instance. Selecting "None" will result in the instance having no external internet access. <a href="https://cloud.google.com/compute/docs/configure-instance-ip-addresses">Learn more</a>
+          minItems: 1
+          maxItems: 8
+          section: networking
+          xGoogleProperty:
+            type: ET_GCE_EXTERNAL_IP
+            gceExternalIp:
+              networkVariable: networks
+              type: IP_EPHEMERAL
+        project_id:
+          name: project_id
+          title: Project Id
+        flatcar_image:
+          name: flatcar_image
+          title: Image version
+          enumValueLabels:
+            - label: stable
+              value: projects/kinvolk-public/global/images/flatcar-stable-${STABLE_VERSION_DASHED}
+            - label: beta
+              value: projects/kinvolk-public/global/images/flatcar-beta-${BETA_VERSION_DASHED}
+            - label: alpha
+              value: projects/kinvolk-public/global/images/flatcar-alpha-${ALPHA_VERSION_DASHED}
+          xGoogleProperty:
+            type: ET_GCE_DISK_IMAGE
+        zone:
+          name: zone
+          title: Zone
+          xGoogleProperty:
+            type: ET_GCE_ZONE
+      sections:
+        - name: networking
+          title: Networking
+          tooltip: Networking related configurations
+        - name: boot_disk
+          title: Boot Disk
+          tooltip: Configure the boot disk

--- a/metadata.yaml.in
+++ b/metadata.yaml.in
@@ -1,0 +1,80 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: flatcar-gcp-marketplace
+  annotations:
+    autogenSpecType: SINGLE_VM
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Flatcar Container Linux on Google Cloud Platform (GCP)
+    source:
+      repo: https://github.com/flatcar/terraform-gcp-flatcar.git
+      sourceType: git
+      dir: /
+    actuationTool:
+      flavor: Terraform
+      version: '>= 1.0'
+    description: {}
+  content:
+    documentation:
+      - title: Flatcar Container Linux Documentation
+        url: https://www.flatcar.org/docs/latest/
+  interfaces:
+    variables:
+    - name: boot_disk_size
+      description: The boot disk size for the VM instance in GBs
+      varType: string
+      defaultValue: "20"
+    - name: boot_disk_type
+      description: The boot disk type for the VM instance.
+      varType: string
+      defaultValue: pd-standard
+    - name: external_ips
+      description: The external IPs assigned to the VM for public access.
+      varType: list(string)
+      defaultValue:
+      - EPHEMERAL
+    - name: goog_cm_deployment_name
+      description: The name of the deployment and VM instance.
+      varType: string
+      required: true
+    - name: machine_type
+      description: The machine type to create, e.g. e2-small
+      varType: string
+      defaultValue: n2-standard-4
+    - name: networks
+      description: The network name to attach the VM instance.
+      varType: list(string)
+      defaultValue:
+      - default
+    - name: project_id
+      description: The ID of the project in which to provision resources.
+      varType: string
+      required: true
+    - name: flatcar_image
+      description: The image name for the disk for the VM instance.
+      varType: string
+      defaultValue: projects/kinvolk-public/global/images/flatcar-stable-${STABLE_VERSION_DASHED}
+    - name: sub_networks
+      description: The sub network name to attach the VM instance.
+      varType: list(string)
+      defaultValue:
+      - default
+    - name: zone
+      description: The zone for the solution to be deployed.
+      varType: string
+      defaultValue: us-west1-a
+    outputs:
+    - name: has_external_ip
+      description: Flag to indicate if the machine has an external IP
+    - name: instance_machine_type
+      description: Machine type for the compute instance
+    - name: instance_nat_ip
+      description: Machine type for the compute instance
+    - name: instance_network
+      description: Machine type for the compute instance
+    - name: instance_self_link
+      description: Self-link for the Wordpress compute instance
+    - name: instance_zone
+      description: Zone for the wordpress compute instance

--- a/variables.tf.in
+++ b/variables.tf.in
@@ -1,0 +1,77 @@
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+// Marketplace requires this variable name to be declared
+variable "goog_cm_deployment_name" {
+  description = "The name of the deployment and VM instance."
+  type        = string
+  default     = "flatcar"
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone to deploy the VM."
+  default     = "us-central1-a"
+}
+
+variable "channel" {
+  type        = string
+  description = "Flatcar channel (e.g. stable, beta, alpha)."
+  default     = "stable"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Compute Engine machine type (e.g., e2-medium, n2-standard-2)."
+  default     = "n2-standard-2"
+}
+
+variable "network" {
+  type        = list(string)
+  description = "List of network names (default is ['default'])."
+  default     = ["default"]
+}
+
+variable "subnetwork" {
+  type        = list(string)
+  description = "List of subnetworks (optional)."
+  default     = []
+}
+
+variable "external_ip" {
+  type        = list(string)
+  description = "List containing external IP addresses (e.g. [EPHEMERAL], [NONE], etc.)."
+  default     = ["EPHEMERAL"]
+}
+
+variable "ip_forward" {
+  type        = string
+  description = "IP forwarding: On or Off."
+  default     = "Off"
+}
+
+variable "boot_disk_type" {
+  type        = string
+  description = "Boot disk type (e.g., pd-ssd, pd-standard, etc.)."
+  default     = "pd-ssd"
+}
+
+variable "boot_disk_size_gb" {
+  type        = number
+  description = "Boot disk size in GB."
+  default     = 10
+}
+
+variable "deployment_name" {
+  type        = string
+  description = "Name prefix for your deployment."
+  default     = "flatcar"
+}
+
+variable "flatcar_image" {
+  type        = string
+  description = "Absolute Flatcar Image URL"
+  default     = "projects/kinvolk-public/global/images/flatcar-stable-${STABLE_VERSION_DASHED}"
+}


### PR DESCRIPTION
GCP requires a deployment package with the terraform. There are 5 files that require version bump during every release. 

We already had a Makefile to create the zip file to upload - but now it's updated to fetch the version after release, update the version in the require files and create the zip 